### PR TITLE
Make project buildable and avoid cost warnings on meeting cancellations

### DIFF
--- a/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
+++ b/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
@@ -227,7 +227,7 @@
     <ManifestKeyFile>MeetingCostAlert_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>10B5A704692F650EE047F90113CC2C0312097ED1</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>08A947D7EA25063B24D8486F18DDECD8097F6F6D</ManifestCertificateThumbprint>
   </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
+++ b/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
@@ -220,15 +220,6 @@
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <PropertyGroup>
-    <SignManifests>true</SignManifests>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestKeyFile>MeetingCostAlert_TemporaryKey.pfx</ManifestKeyFile>
-  </PropertyGroup>
-  <PropertyGroup>
-    <ManifestCertificateThumbprint>10B5A704692F650EE047F90113CC2C0312097ED1</ManifestCertificateThumbprint>
-  </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Include additional build rules for an Office application add-in. -->

--- a/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
+++ b/src/MeetingCostAlert/MeetingCostAlert/MeetingCostAlert.csproj
@@ -227,7 +227,7 @@
     <ManifestKeyFile>MeetingCostAlert_TemporaryKey.pfx</ManifestKeyFile>
   </PropertyGroup>
   <PropertyGroup>
-    <ManifestCertificateThumbprint>08A947D7EA25063B24D8486F18DDECD8097F6F6D</ManifestCertificateThumbprint>
+    <ManifestCertificateThumbprint>10B5A704692F650EE047F90113CC2C0312097ED1</ManifestCertificateThumbprint>
   </PropertyGroup>
   <!-- Include the build rules for a C# project. -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
+++ b/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
@@ -36,15 +36,11 @@ namespace MeetingCostAlert
                 AppointmentItem appointment = meeting.GetAssociatedAppointment(false);
                 RecurrencePattern recurrancePattern = appointment.GetRecurrencePattern();
 
-                if (meeting.Class == OlObjectClass.olMeetingCancellation)
-                {
-                    return;
-                }
-
                 if (!IsOrganizedByCurrentUser(appointment))
                 {
                     return;
                 }
+
                 int attendees = appointment.Recipients.Count;
                 TimeSpan duration = TimeSpan.FromMinutes(appointment.Duration);
 

--- a/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
+++ b/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
@@ -41,6 +41,11 @@ namespace MeetingCostAlert
                     return;
                 }
 
+                if (meeting.Class == OlObjectClass.olMeetingCancellation)
+                {
+                    return;
+                }
+
                 int attendees = appointment.Recipients.Count;
                 TimeSpan duration = TimeSpan.FromMinutes(appointment.Duration);
 

--- a/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
+++ b/src/MeetingCostAlert/MeetingCostAlert/ThisAddIn.cs
@@ -36,11 +36,15 @@ namespace MeetingCostAlert
                 AppointmentItem appointment = meeting.GetAssociatedAppointment(false);
                 RecurrencePattern recurrancePattern = appointment.GetRecurrencePattern();
 
-                if (!IsOrganizedByCurrentUser(appointment))
+                if (meeting.Class == OlObjectClass.olMeetingCancellation)
                 {
                     return;
                 }
 
+                if (!IsOrganizedByCurrentUser(appointment))
+                {
+                    return;
+                }
                 int attendees = appointment.Recipients.Count;
                 TimeSpan duration = TimeSpan.FromMinutes(appointment.Duration);
 


### PR DESCRIPTION
Plug in will now no longer show cost warnings when sending a cancellation notice to meetings which surpass the cost threshold.

Additionally, the project is now buildable.